### PR TITLE
Include package.json and yarn.lock in the asset cache checksum

### DIFF
--- a/build.go
+++ b/build.go
@@ -49,7 +49,8 @@ type EnvironmentSetup interface {
 //   extra directories defined by the user.
 //   2. Calculate a checksum of the asset directories that appear in the
 //   working directory. These directories include app/assets, lib/assets,
-//   vendor/assets, app/javascript, and the user defined checksum directories.
+//   vendor/assets, app/javascript, the package.json and yarn.lock JS
+//   dependency manifests, and the user defined checksum directories.
 //   3. Compare the calculated checksum against the recorded value on the
 //   "assets" layer metadata.
 //   3a. If the checksum matches the recorded value, the build process
@@ -88,6 +89,14 @@ func Build(
 			filepath.Join(context.WorkingDir, "lib", "assets"),
 			filepath.Join(context.WorkingDir, "vendor", "assets"),
 			filepath.Join(context.WorkingDir, "app", "javascript"),
+			// JS dependency/lockfiles: jsbundling (esbuild/webpack) pulls asset
+			// source from node_modules, so a dependency or lockfile change can
+			// alter compiled output without touching any of the directories
+			// above. Including these makes such changes invalidate the cache and
+			// trigger a fresh precompile. Each is existence-filtered below, so
+			// non-JS apps are unaffected.
+			filepath.Join(context.WorkingDir, "package.json"),
+			filepath.Join(context.WorkingDir, "yarn.lock"),
 		}
 
 		extraPaths := filepath.SplitList(os.Getenv("BP_RAILS_ASSETS_EXTRA_SOURCE_PATHS"))

--- a/build.go
+++ b/build.go
@@ -49,8 +49,9 @@ type EnvironmentSetup interface {
 //   extra directories defined by the user.
 //   2. Calculate a checksum of the asset directories that appear in the
 //   working directory. These directories include app/assets, lib/assets,
-//   vendor/assets, app/javascript, the package.json and yarn.lock JS
-//   dependency manifests, and the user defined checksum directories.
+//   vendor/assets, app/javascript, the JS dependency manifests and
+//   lockfiles (package.json, yarn.lock, package-lock.json, pnpm-lock.yaml),
+//   and the user defined checksum directories.
 //   3. Compare the calculated checksum against the recorded value on the
 //   "assets" layer metadata.
 //   3a. If the checksum matches the recorded value, the build process
@@ -93,10 +94,12 @@ func Build(
 			// source from node_modules, so a dependency or lockfile change can
 			// alter compiled output without touching any of the directories
 			// above. Including these makes such changes invalidate the cache and
-			// trigger a fresh precompile. Each is existence-filtered below, so
-			// non-JS apps are unaffected.
+			// trigger a fresh precompile. Cover yarn, npm and pnpm lockfiles.
+			// Each is existence-filtered below, so non-JS apps are unaffected.
 			filepath.Join(context.WorkingDir, "package.json"),
 			filepath.Join(context.WorkingDir, "yarn.lock"),
+			filepath.Join(context.WorkingDir, "package-lock.json"),
+			filepath.Join(context.WorkingDir, "pnpm-lock.yaml"),
 		}
 
 		extraPaths := filepath.SplitList(os.Getenv("BP_RAILS_ASSETS_EXTRA_SOURCE_PATHS"))

--- a/build_test.go
+++ b/build_test.go
@@ -250,6 +250,33 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when there are package.json and yarn.lock files", func() {
+			it.Before(func() {
+				Expect(os.RemoveAll(filepath.Join(workingDir, "app", "assets"))).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "package.json"), []byte("{}"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), 0600)).To(Succeed())
+			})
+
+			it("includes them in the checksum so dependency changes invalidate the cache", func() {
+				_, err := build(packit.BuildContext{
+					WorkingDir: workingDir,
+					CNBPath:    cnbDir,
+					Stack:      "some-stack",
+					BuildpackInfo: packit.BuildpackInfo{
+						Name:    "Some Buildpack",
+						Version: "some-version",
+					},
+					Layers: packit.Layers{Path: layersDir},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(calculator.SumCall.Receives.Paths).To(Equal([]string{
+					filepath.Join(workingDir, "package.json"),
+					filepath.Join(workingDir, "yarn.lock"),
+				}))
+			})
+		})
+
 		context("when there are extra assets directories", func() {
 			it.Before(func() {
 				os.Setenv("BP_RAILS_ASSETS_EXTRA_SOURCE_PATHS", "custom/assets")

--- a/build_test.go
+++ b/build_test.go
@@ -250,11 +250,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
-		context("when there are package.json and yarn.lock files", func() {
+		context("when there are JS dependency manifests and lockfiles", func() {
 			it.Before(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, "app", "assets"))).To(Succeed())
-				Expect(os.WriteFile(filepath.Join(workingDir, "package.json"), []byte("{}"), 0600)).To(Succeed())
-				Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "package.json"), []byte("{}"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte("{}"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "pnpm-lock.yaml"), []byte(""), 0644)).To(Succeed())
 			})
 
 			it("includes them in the checksum so dependency changes invalidate the cache", func() {
@@ -273,6 +275,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(calculator.SumCall.Receives.Paths).To(Equal([]string{
 					filepath.Join(workingDir, "package.json"),
 					filepath.Join(workingDir, "yarn.lock"),
+					filepath.Join(workingDir, "package-lock.json"),
+					filepath.Join(workingDir, "pnpm-lock.yaml"),
 				}))
 			})
 		})


### PR DESCRIPTION
The rails-assets layer is reused whenever a checksum of `app/assets`, `lib/assets`, `vendor/assets` and `app/javascript` is unchanged. But neeto apps compile their frontend with jsbundling (esbuild), which pulls asset source from `node_modules` — so a JS dependency bump or a `yarn.lock` change alters the compiled output without touching any of those directories. The buildpack then reuses a stale precompiled layer, the freshly built assets are discarded, and the app ships JS that no longer matches its source. This is one of the ways "assets are not updated after a release" shows up on neetoDeploy.

- Add `package.json` and `yarn.lock` to the checksum paths so dependency and lockfile changes invalidate the assets cache and trigger a fresh precompile
- Both are existence-filtered like the existing paths, so Rails apps without a JS build are unaffected
- Added a unit test covering the new paths

Note: this closes the dependency-driven staleness vector. Apps that use npm (`package-lock.json`) rather than yarn are a natural follow-up.

There is one pre-existing unit failure on main unrelated to this change (`Detect/when_the_Gemfile_does_not_list_rails`); left untouched.